### PR TITLE
Use portal for drawer

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -7,6 +7,7 @@ interface Props {
   children?: React.ReactNode;
   sideContent: React.ReactNode;
   end?: boolean;
+  disablePortal?: boolean;
 }
 
 function Drawer(props: Props) {
@@ -16,6 +17,7 @@ function Drawer(props: Props) {
     children = null,
     sideContent,
     end = false,
+    disablePortal = false,
   } = props;
 
   const ref = useRef<Element | null>(null);
@@ -26,32 +28,35 @@ function Drawer(props: Props) {
     setMounted(true);
   }, []);
 
-  return mounted && ref.current
-    ? createPortal(
+  const drawer = () => (
+    <div
+      className={`drawer fixed top-0 left-0 w-full h-full ${
+        end ? "drawer-end" : ""
+      }`}
+    >
+      <input
+        type="checkbox"
+        className="drawer-toggle"
+        checked={isVisible}
+        readOnly
+      />
+      <div className="drawer-content">{children}</div>
+      <div className="drawer-side">
         <div
-          className={`drawer fixed top-0 left-0 w-full h-full ${
-            end ? "drawer-end" : ""
-          }`}
-        >
-          <input
-            type="checkbox"
-            className="drawer-toggle"
-            checked={isVisible}
-            readOnly
-          />
-          <div className="drawer-content">{children}</div>
-          <div className="drawer-side">
-            <div
-              role="presentation"
-              className="drawer-overlay"
-              onClick={onOverlayClick}
-            />
-            <div className="w-80 bg-base-100">{sideContent}</div>
-          </div>
-        </div>,
-        document.body
-      )
-    : null;
+          role="presentation"
+          className="drawer-overlay"
+          onClick={onOverlayClick}
+        />
+        <div className="w-80 bg-base-100">{sideContent}</div>
+      </div>
+    </div>
+  );
+
+  if (disablePortal) {
+    return <>{drawer()}</>;
+  }
+
+  return mounted && ref.current ? createPortal(drawer(), document.body) : null;
 }
 
 export default Drawer;

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface Props {
   isVisible: boolean;
@@ -16,30 +17,41 @@ function Drawer(props: Props) {
     sideContent,
     end = false,
   } = props;
-  return (
-    <div
-      className={`
-        drawer fixed top-0 left-0 w-full h-full
-        ${end ? "drawer-end" : ""} 
-    `}
-    >
-      <input
-        type="checkbox"
-        className="drawer-toggle"
-        checked={isVisible}
-        readOnly
-      />
-      <div className="drawer-content">{children}</div>
-      <div className="drawer-side">
+
+  const ref = useRef<Element | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    ref.current = document.querySelector<HTMLElement>("body");
+    setMounted(true);
+  }, []);
+
+  return mounted && ref.current
+    ? createPortal(
         <div
-          role="presentation"
-          className="drawer-overlay"
-          onClick={onOverlayClick}
-        />
-        <div className="w-80 bg-base-100">{sideContent}</div>
-      </div>
-    </div>
-  );
+          className={`drawer fixed top-0 left-0 w-full h-full ${
+            end ? "drawer-end" : ""
+          }`}
+        >
+          <input
+            type="checkbox"
+            className="drawer-toggle"
+            checked={isVisible}
+            readOnly
+          />
+          <div className="drawer-content">{children}</div>
+          <div className="drawer-side">
+            <div
+              role="presentation"
+              className="drawer-overlay"
+              onClick={onOverlayClick}
+            />
+            <div className="w-80 bg-base-100">{sideContent}</div>
+          </div>
+        </div>,
+        document.body
+      )
+    : null;
 }
 
 export default Drawer;

--- a/src/stories/Drawer.stories.tsx
+++ b/src/stories/Drawer.stories.tsx
@@ -18,3 +18,17 @@ Default.args = {
   sideContent: <div>Side Content</div>,
   onOverlayClick: () => {},
 };
+
+export const PortalDisabled: ComponentStory<typeof Drawer> = (args) => {
+  const { children } = args;
+  return <Drawer {...args}>{children}</Drawer>;
+};
+
+PortalDisabled.args = {
+  isVisible: true,
+  children: "Page contents",
+  end: false,
+  sideContent: <div>Side Content</div>,
+  onOverlayClick: () => {},
+  disablePortal: true,
+};


### PR DESCRIPTION
- It is a common practice to use a portal for drawers to avoid drawers being rendered within the dom tree along with the page's content. A portal allows rendering the drawer content outside the tree of the page.
- Current PR renders drawers on the client side, in the dom tree, and outside the page content using a portal.